### PR TITLE
Use `env python3`, add --save-frames

### DIFF
--- a/pixelsort.py
+++ b/pixelsort.py
@@ -398,7 +398,8 @@ def get_cli_args():
     parser.add_argument("--animate", type=str_to_animate_params, default=None,
                         help="Animate a certain parameter. "
                              "This argument is a string '<param> <start> <stop> <n_steps>'")
-    parser.add_argument("--save-frames", action='store_true', default=False)
+    parser.add_argument("--save-frames", action='store_true', default=False,
+                        help="Whether to save animation frames as individual pictures")
     args = parser.parse_args()
     return args
 


### PR DESCRIPTION
I'm liking the animation code a lot so far!
I added a flag to save the individual animation frames, as I feel like they are not necessarily desired when making a gif. Using `/usr/bin/env python3` will call python3 on systems where `python` might mean python2, just a little nitpick!

I'll probably start working on something to process animated gif as input files in the coming days, unless you beat me to the punch!