### PR TITLE
Fix error with using "random" module directly

### DIFF
--- a/pixelsorter/util.py
+++ b/pixelsorter/util.py
@@ -76,7 +76,7 @@ def weighted_random_choice(items):
     :return: A random object, whose likelihood is proportional to its weight.
     """
     l = list(items)
-    r = random * sum([i[1] for i in l])
+    r = random.random() * sum([i[1] for i in l])
     for x, p in l:
         if p > r:
             return x


### PR DESCRIPTION
Hello! I was using your tool to sort some images today and I noticed an issue with the random generation for the walk path types.

```
$ python pixelsort ~/image.jpg -o sorted.jpg -i 100 -r -p random-walk-horizontal
Traceback (most recent call last):
  File "pixelsort", line 327, in <module>
    main()
  File "pixelsort", line 290, in main
    channel=args.channel, pixels=None, save=True)
  File "pixelsort", line 55, in sort_image_with_cli_args
    out_pixels = sort_image(pixels, image.size, **sorting_args)
  File "/home/delucks/software/pixelsorter/pixelsorter/sort.py", line 202, in sort_image
    coords = next(row_iter)
  File "/home/delucks/software/pixelsorter/pixelsorter/paths.py", line 186, in random_walk_iter
    dx, dy = weighted_random_choice(iter(distribution.items()))
  File "/home/delucks/software/pixelsorter/pixelsorter/util.py", line 79, in weighted_random_choice
    r = random * sum([i[1] for i in l])
TypeError: unsupported operand type(s) for *: 'module' and 'float'
```

Looking into it, the function `weighted_random_choice` is using the `random` module as an operand for this selection of random weight. It looks like the intention there is to call `random.random()` to get a float somewhere in the range of `(0.0, 1.0)`, so I modified the code to fix this. All random-walk paths work now.